### PR TITLE
Add rack middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.1.4] - Unreleased
 
+### Added
+
+- Ability to use CloseEncounters::Middleware and CloseEncounters.auto_contact! to automatically track responses from third-party services.
+
 ## [0.1.3] - 2024-07-11

--- a/lib/close_encounters.rb
+++ b/lib/close_encounters.rb
@@ -19,6 +19,22 @@ module CloseEncounters
     end
   end
 
+  # Determine if contacts with third party services should be recorded automatically
+  # using the Rack Middleware
+  #
+  # Set the CLOSE_ENCOUNTERS_AUTO_CONTACT environment variable to enable this feature
+  # or call CloseEncounters.auto_contact! in an initializer
+  #
+  # @return [Boolean] whether or not to automatically record contacts
+  def auto_contact?
+    !!(ENV["CLOSE_ENCOUNTERS_AUTO_CONTACT"] || @auto_contact)
+  end
+
+  # Enable automatic contact recording in the Rack Middleware
+  def auto_contact!
+    @auto_contact = true
+  end
+
   # Get the status of the most recent contact with a third party service
   #
   # @param name [String] the name of the service

--- a/lib/close_encounters/engine.rb
+++ b/lib/close_encounters/engine.rb
@@ -1,9 +1,14 @@
+require_relative "middleware"
 module CloseEncounters
   class Engine < ::Rails::Engine
     isolate_namespace CloseEncounters
 
     config.generators do |g|
       g.test_framework :minitest, spec: true
+    end
+
+    initializer "close_encounters.middleware" do |app|
+      app.middleware.use CloseEncounters::Middleware if CloseEncounters.auto_contact?
     end
 
     if defined?(Importmap)

--- a/lib/close_encounters/middleware.rb
+++ b/lib/close_encounters/middleware.rb
@@ -1,0 +1,31 @@
+module CloseEncounters
+  class Middleware
+    def initialize(app, tracker: CloseEncounters)
+      @app = app
+      @tracker = tracker
+    end
+
+    def call(env)
+      status, headers, response = @app.call(env)
+
+      record_contact(env["SERVER_NAME"], status, response)
+
+      [status, headers, response]
+    end
+
+    private
+
+    def record_contact(host, status, response)
+      if (name = participant_services[host])
+        @tracker.contact(name, status:, response:)
+      end
+    end
+
+    def participant_services
+      @participant_services ||= CloseEncounters::ParticipantService.all
+        .map do |service|
+          [service.connection_info["domain"], service.name]
+        end.to_h
+    end
+  end
+end

--- a/test/close_encounters_test.rb
+++ b/test/close_encounters_test.rb
@@ -4,6 +4,24 @@ module CloseEncounters
   class CloseEncountersTest < ActiveSupport::TestCase
     fixtures :all
 
+    test ".auto_contact? returns true if the environment variable is set" do
+      begin
+        ENV["CLOSE_ENCOUNTERS_AUTO_CONTACT"] = "true"
+        _(CloseEncounters.auto_contact?).must_equal true
+      ensure
+        ENV.delete("CLOSE_ENCOUNTERS_AUTO_CONTACT")
+      end
+    end
+
+    test ".auto_contact? returns false if the environment variable is not set" do
+      _(CloseEncounters.auto_contact?).must_equal false
+    end
+
+    test ".auto_contact! enables automatic contact recording" do
+      CloseEncounters.auto_contact!
+      _(CloseEncounters.auto_contact?).must_equal true
+    end
+
     test ".contact creates a new event if the status has changed" do
       service = close_encounters_participant_services(:aliens)
       # _working_event = close_encounters_participant_events(:working)

--- a/test/fixtures/close_encounters/participant_services.yml
+++ b/test/fixtures/close_encounters/participant_services.yml
@@ -1,17 +1,16 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 aliens:
   name: aliens
   connection_info: >
     {
       "key": "123",
-      "secret": "456"
+      "secret": "456",
+      "domain": "service.example"
     }
-
 others:
   name: others
   connection_info: >
     {
-      "user": "user"
-      "password": "password"
+      "user": "user",
+      "stuff": "stuff",
+      "domain": "other.service.example"
     }

--- a/test/lib/middleware_test.rb
+++ b/test/lib/middleware_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "minitest/mock"
+
+module CloseEncounters
+  class MiddlewareTest < ActiveSupport::TestCase
+    def setup
+      @app = ->(env) { [200, env, "app"] }
+      @mock = Minitest::Mock.new(CloseEncounters)
+    end
+
+    def teardown
+      @mock.verify
+    end
+
+    test "calls contact when domain matches" do
+      fixture = close_encounters_participant_services(:aliens)
+      @mock.expect(:contact, true, [fixture.name], status: 200, response: "app")
+      middleware = CloseEncounters::Middleware.new(@app, tracker: @mock)
+
+      env = {"SERVER_NAME" => "service.example"}
+      middleware.call(env)
+    end
+
+    test "does not call contact when domain doesn't match" do
+      env = {"SERVER_NAME" => "untracked.example"}
+      middleware = CloseEncounters::Middleware.new(@app, tracker: @mock)
+      CloseEncounters.stub(:contact, nil) do
+        assert middleware.call(env)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/SOFware/close_encounters/issues/7

Add a `CloseEncounters::Middleware` to track the response from third-party requests automatically.