### PR TITLE
Fix code scanning alert no. 1: CSRF protection not enabled

### DIFF
--- a/test/dummy/app/controllers/application_controller.rb
+++ b/test/dummy/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
Fixes [https://github.com/SOFware/close_encounters/security/code-scanning/1](https://github.com/SOFware/close_encounters/security/code-scanning/1)

To fix the CSRF vulnerability, we need to enable CSRF protection in the `ApplicationController` class. The best way to do this in a Rails application is to use the `protect_from_forgery` method with the `:exception` strategy. This will raise an exception if an invalid CSRF token is encountered, providing a robust defense against CSRF attacks.

**Steps to implement the fix:**
1. Add the `protect_from_forgery with: :exception` line to the `ApplicationController` class.
2. Ensure that this change is made in the `test/dummy/app/controllers/application_controller.rb` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
