### PR TITLE
Event-metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Ability to use CloseEncounters::Middleware and CloseEncounters.auto_contact! to automatically track responses from third-party services.
+- Add metadata to events for storing extra information about the event.
 
 ## [0.1.3] - 2024-07-11

--- a/app/models/close_encounters/participant_event.rb
+++ b/app/models/close_encounters/participant_event.rb
@@ -6,5 +6,9 @@ module CloseEncounters
       foreign_key: "close_encounters_participant_service_id"
 
     scope :newest, -> { order(created_at: :desc).limit(1) }
+
+    unless ActiveRecord::Base.connection.adapter_name.downcase.include?("postgresql")
+      serialize :metadata, coder: JSON
+    end
   end
 end

--- a/db/migrate/20250225232551_add_metadata_to_close_encounters_participant_events.rb
+++ b/db/migrate/20250225232551_add_metadata_to_close_encounters_participant_events.rb
@@ -1,0 +1,9 @@
+class AddMetadataToCloseEncountersParticipantEvents < ActiveRecord::Migration[7.1]
+  def change
+    if ActiveRecord::Base.connection.adapter_name.downcase.include?("postgresql")
+      add_column :close_encounters_participant_events, :metadata, :jsonb
+    else
+      add_column :close_encounters_participant_events, :metadata, :text
+    end
+  end
+end

--- a/lib/close_encounters.rb
+++ b/lib/close_encounters.rb
@@ -19,6 +19,23 @@ module CloseEncounters
     end
   end
 
+  # Record a verification of a contact with a third party service where the
+  # verification is a callable which must also respond to to_s.
+  #
+  # For example, provide a callable which checks the JSON Schema for a response body
+  # and will record an event if calling the verification returns false.
+  #
+  # @param name [String] the name of the service
+  # @param status [Integer] the HTTP status of the contact
+  # @param response [String] the response object
+  # @param verifier [Proc] the verification callable which must also respond to to_s
+  def verify(name, status:, response:, verifier:)
+    service = ParticipantService.find_by!(name:)
+    unless service.events.newest.pick(:status) == status && (verified = verifier.call(response))
+      service.events.create!(status:, response:, metadata: {verified:, verification: verifier.to_s})
+    end
+  end
+
   # Determine if contacts with third party services should be recorded automatically
   # using the Rack Middleware
   #

--- a/test/close_encounters_test.rb
+++ b/test/close_encounters_test.rb
@@ -45,6 +45,23 @@ module CloseEncounters
       expect { CloseEncounters.contact("service", status: 200, response: "Yay! Everything worked.") }.must_raise ActiveRecord::RecordNotFound
     end
 
+    class Verification
+      def call(response)
+        response == "Yay! Everything worked."
+      end
+
+      def to_s
+        "Verification"
+      end
+    end
+
+    test ".verify creates a new event if the status and verification are met" do
+      service = close_encounters_participant_services(:aliens)
+      CloseEncounters.verify("aliens", status: 200, response: "Yay! Everything worked.", verifier: Verification.new)
+      CloseEncounters.verify("aliens", status: 200, response: "Nope! Everything failed.", verifier: Verification.new)
+      _(service.events.count).must_equal 2
+    end
+
     test ".status returns the status of the most recent event" do
       service = close_encounters_participant_services(:aliens)
       service.events.create!(status: 200, response: "Yay! Everything worked.")

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_08_190642) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_25_232551) do
   create_table "close_encounters_participant_events", force: :cascade do |t|
     t.text "response"
     t.integer "close_encounters_participant_service_id", null: false
     t.integer "status", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "metadata"
     t.index ["close_encounters_participant_service_id"], name: "idx_on_close_encounters_participant_service_id_4e69f5fd33"
   end
 

--- a/test/lib/middleware_test.rb
+++ b/test/lib/middleware_test.rb
@@ -18,7 +18,8 @@ module CloseEncounters
       middleware = CloseEncounters::Middleware.new(@app, tracker: @mock)
 
       env = {"SERVER_NAME" => "service.example"}
-      middleware.call(env)
+      result = middleware.call(env)
+      assert_equal [200, env, "app"], result
     end
 
     test "does not call contact when domain doesn't match" do

--- a/test/models/close_encounters/participant_event_test.rb
+++ b/test/models/close_encounters/participant_event_test.rb
@@ -16,5 +16,11 @@ module CloseEncounters
 
       assert_equal event2, ParticipantEvent.newest.first
     end
+
+    it "can store metadata" do
+      service = ParticipantService.create!(name: "test")
+      event = service.events.create!(status: 200, response: "OK", metadata: {foo: "bar"})
+      assert_equal({"foo" => "bar"}, event.metadata)
+    end
   end
 end


### PR DESCRIPTION
Store metadata in events.
Add a `CloseEncounters.verify` method to check the response against a verifier callable object and store the result in the event metadata.