### PR TITLE
Update verification handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.1] - Unreleased
 
+### Added
+
+- Add alias for verify method as scan.
+
 ## [0.2.0] - 2025-02-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add alias for verify method as scan.
+- Add configuration for auto_contact and verify_scan_statuses.
+
+### Changed
+
+- Ensure that events are only created if the status has changed or if the status is in the verify_scan_statuses list and verification fails.
 
 ## [0.2.0] - 2025-02-26
 

--- a/app/models/close_encounters/participant_event.rb
+++ b/app/models/close_encounters/participant_event.rb
@@ -10,5 +10,9 @@ module CloseEncounters
     unless ActiveRecord::Base.connection.adapter_name.downcase.include?("postgresql")
       serialize :metadata, coder: JSON
     end
+
+    def verified?
+      !!metadata.to_h.dig("verified")
+    end
   end
 end

--- a/lib/close_encounters.rb
+++ b/lib/close_encounters.rb
@@ -29,12 +29,14 @@ module CloseEncounters
   # @param status [Integer] the HTTP status of the contact
   # @param response [String] the response object
   # @param verifier [Proc] the verification callable which must also respond to to_s
-  def verify(name, status:, response:, verifier:)
+  def scan(name, status:, response:, verifier:)
     service = ParticipantService.find_by!(name:)
     unless service.events.newest.pick(:status) == status && (verified = verifier.call(response))
       service.events.create!(status:, response:, metadata: {verified:, verification: verifier.to_s})
     end
   end
+  alias_method :verify, :scan
+  module_function :verify
 
   # Determine if contacts with third party services should be recorded automatically
   # using the Rack Middleware

--- a/lib/close_encounters.rb
+++ b/lib/close_encounters.rb
@@ -7,6 +7,23 @@ module CloseEncounters
   autoload :ParticipantService, "close_encounters/participant_service"
   autoload :ParticipantEvent, "close_encounters/participant_event"
 
+  class Configuration
+    attr_accessor :auto_contact, :verify_scan_statuses
+
+    def initialize
+      @auto_contact = !!ENV["CLOSE_ENCOUNTERS_AUTO_CONTACT"]
+      @verify_scan_statuses = [200, 201]
+    end
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
   # Record a contact with a third party service if the status has changed
   #
   # @param name [String] the name of the service
@@ -45,13 +62,11 @@ module CloseEncounters
   # or call CloseEncounters.auto_contact! in an initializer
   #
   # @return [Boolean] whether or not to automatically record contacts
-  def auto_contact?
-    !!(ENV["CLOSE_ENCOUNTERS_AUTO_CONTACT"] || @auto_contact)
-  end
+  def auto_contact? = configuration.auto_contact
 
   # Enable automatic contact recording in the Rack Middleware
   def auto_contact!
-    @auto_contact = true
+    configuration.auto_contact = true
   end
 
   # Get the status of the most recent contact with a third party service

--- a/test/close_encounters_test.rb
+++ b/test/close_encounters_test.rb
@@ -4,6 +4,17 @@ module CloseEncounters
   class CloseEncountersTest < ActiveSupport::TestCase
     fixtures :all
 
+    test ".configure sets the configuration" do
+      CloseEncounters.configure do |config|
+        config.auto_contact = true
+        config.verify_scan_statuses = [1, 999]
+      end
+
+      _(CloseEncounters.configuration.auto_contact).must_equal true
+    ensure
+      CloseEncounters.remove_instance_variable(:@configuration)
+    end
+
     test ".auto_contact? returns true if the environment variable is set" do
       ENV["CLOSE_ENCOUNTERS_AUTO_CONTACT"] = "true"
       _(CloseEncounters.auto_contact?).must_equal true
@@ -13,7 +24,7 @@ module CloseEncounters
 
     test ".auto_contact? returns false if the environment variable is not set" do
       ENV.delete("CLOSE_ENCOUNTERS_AUTO_CONTACT")
-      CloseEncounters.remove_instance_variable(:@auto_contact) if CloseEncounters.instance_variable_defined?(:@auto_contact)
+      CloseEncounters.remove_instance_variable(:@configuration) if CloseEncounters.instance_variable_defined?(:@configuration)
       _(CloseEncounters.auto_contact?).must_equal false
     end
 

--- a/test/close_encounters_test.rb
+++ b/test/close_encounters_test.rb
@@ -55,10 +55,10 @@ module CloseEncounters
       end
     end
 
-    test ".verify creates a new event if the status and verification are met" do
+    test ".scan creates a new event if the status and verification are met" do
       service = close_encounters_participant_services(:aliens)
-      CloseEncounters.verify("aliens", status: 200, response: "Yay! Everything worked.", verifier: Verification.new)
-      CloseEncounters.verify("aliens", status: 200, response: "Nope! Everything failed.", verifier: Verification.new)
+      CloseEncounters.scan("aliens", status: 200, response: "Yay! Everything worked.", verifier: Verification.new)
+      CloseEncounters.scan("aliens", status: 200, response: "Nope! Everything failed.", verifier: Verification.new)
       _(service.events.count).must_equal 2
     end
 

--- a/test/models/close_encounters/participant_event_test.rb
+++ b/test/models/close_encounters/participant_event_test.rb
@@ -22,5 +22,19 @@ module CloseEncounters
       event = service.events.create!(status: 200, response: "OK", metadata: {foo: "bar"})
       assert_equal({"foo" => "bar"}, event.metadata)
     end
+
+    it "can check if an event is verified" do
+      service = ParticipantService.create!(name: "test")
+      event = service.events.build(status: 200, response: "OK", metadata: {verified: true})
+      assert event.verified?
+      event.metadata = {verified: false}
+      refute event.verified?
+    end
+
+    it "is not verified if the metadata is not present" do
+      service = ParticipantService.create!(name: "test")
+      event = service.events.build(status: 200, response: "OK")
+      refute event.verified?
+    end
   end
 end


### PR DESCRIPTION
The event should only be created if the status does not match the last recorded or if the status is in the list of verified statuses and failed verification.