### PR TITLE
Lock the table when creating events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       NOTIFY_SLACK_NOTIFY_CHANNEL: "oss-notices"
       NOTIFY_CURRENT_REPOSITORY_URL: "${{ github.server_url }}/${{ github.repository }}"
       NOTIFY_TEST_RUN_ID: "${{ github.run_id }}"
-      CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -40,14 +39,44 @@ jobs:
         run: |
           # this is to fix GIT not liking owner of the checkout dir
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - uses: amancevice/setup-code-climate@v2
-        with:
-          cc_test_reporter_id: ${{ secrets.CC_TEST_REPORTER_ID }}
-      - run: cc-test-reporter before-build
       - name: Test
         run: bundle exec rake
-      - run: cc-test-reporter after-build
-        if: ${{ github.event_name != 'pull_request' }}
+      - name: Upload coverage resultset
+        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-resultset-${{ github.sha }}
+          path: coverage/.resultset.json
+          retention-days: 30
+
+  coverage:
+    name: Coverage Comparison
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download base branch coverage
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: test.yml
+          branch: ${{ github.event.pull_request.base.ref }}
+          name: coverage-resultset-*
+          name_is_regexp: true
+          path: base-coverage
+          if_no_artifact_found: warn
+      - name: Download head branch coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-resultset-${{ github.sha }}
+          path: head-coverage
+      - name: SimpleCov Resultset Diff
+        uses: kzkn/simplecov-resultset-diff-action@v1
+        with:
+          base-resultset-path: base-coverage/.resultset.json
+          head-resultset-path: head-coverage/.resultset.json
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
 
   linter:
     name: Linter

--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,9 @@
 SimpleCov.start "rails" do
+  # Use simple formatter in CI for cleaner output
+  if ENV["CI"] == "true"
+    formatter SimpleCov::Formatter::SimpleFormatter
+  end
+
   add_filter "version.rb"
   add_filter "test"
   add_filter "lib/tasks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update handling of the same status for multiple requests when creating events.
 
+### Fixed
+
+- Ensure that status is an integer when creating events and comparing results.
+
 ## [0.2.1] - 2025-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.2] - Unreleased
 
+### Changed
+
+- Update handling of the same status for multiple requests when creating events.
+
 ## [0.2.1] - 2025-03-05
 
 ### Added

--- a/lib/close_encounters.rb
+++ b/lib/close_encounters.rb
@@ -31,6 +31,7 @@ module CloseEncounters
   # @param response [String] the response object
   def contact(name, status:, response:)
     service = ParticipantService.find_by!(name:)
+    status = status.to_i # Ensure status is always an integer
 
     # Use a transaction with a lock to prevent race conditions
     service.with_lock do
@@ -53,6 +54,7 @@ module CloseEncounters
   # @param verifier [Proc] the verification callable which must also respond to to_s
   def scan(name, status:, response:, verifier:)
     service = ParticipantService.find_by!(name:)
+    status = status.to_i # Ensure status is always an integer
 
     service.with_lock do
       if service.events.newest.pick(:status) != status

--- a/lib/close_encounters.rb
+++ b/lib/close_encounters.rb
@@ -31,8 +31,12 @@ module CloseEncounters
   # @param response [String] the response object
   def contact(name, status:, response:)
     service = ParticipantService.find_by!(name:)
-    unless service.events.newest.pick(:status) == status
-      service.events.create!(status: status, response:)
+
+    # Use a transaction with a lock to prevent race conditions
+    service.with_lock do
+      unless service.events.newest.pick(:status) == status
+        service.events.create!(status: status, response:)
+      end
     end
   end
 
@@ -49,14 +53,15 @@ module CloseEncounters
   # @param verifier [Proc] the verification callable which must also respond to to_s
   def scan(name, status:, response:, verifier:)
     service = ParticipantService.find_by!(name:)
-    last_status = service.events.newest.pick(:status)
 
-    if last_status != status
-      verified = verifier.call(response)
-      service.events.create!(status:, response:, metadata: {verified:, verification: verifier.to_s})
-    elsif verify_scan_statuses.include?(status)
-      verified = verifier.call(response)
-      service.events.create!(status:, response:, metadata: {verified:, verification: verifier.to_s}) if !verified
+    service.with_lock do
+      if service.events.newest.pick(:status) != status
+        verified = verifier.call(response)
+        service.events.create!(status:, response:, metadata: {verified:, verification: verifier.to_s})
+      elsif verify_scan_statuses.include?(status)
+        verified = verifier.call(response)
+        service.events.create!(status:, response:, metadata: {verified:, verification: verifier.to_s}) if !verified
+      end
     end
   end
   alias_method :verify, :scan

--- a/test/close_encounters_lock_test.rb
+++ b/test/close_encounters_lock_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+module CloseEncounters
+  class CloseEncountersLockTest < ActiveSupport::TestCase
+    test ".scan with lock prevents duplicate events when status hasn't changed" do
+      service = ParticipantService.create!(name: "scan_lock_test")
+      service.events.create!(status: 200, response: "Initial")
+
+      verifier = ->(response) { true }
+      verifier.define_singleton_method(:to_s) { "always true verifier" }
+
+      # Multiple rapid calls with same status should only keep the original event
+      3.times do
+        CloseEncounters.scan("scan_lock_test", status: 200, response: "Same status", verifier: verifier)
+      end
+
+      # Should still only have 1 event since status didn't change and verification passed
+      assert_equal 1, service.events.count
+    end
+
+    test ".scan with lock creates event when verification fails for verify_scan_statuses" do
+      service = ParticipantService.create!(name: "scan_verify_fail")
+      service.events.create!(status: 200, response: "Initial good")
+
+      failing_verifier = ->(response) { false }
+      failing_verifier.define_singleton_method(:to_s) { "always fails verifier" }
+
+      # Status 200 is in verify_scan_statuses by default
+      # When verification fails, it should create a new event even with same status
+      CloseEncounters.scan("scan_verify_fail", status: 200, response: "Bad response", verifier: failing_verifier)
+
+      assert_equal 2, service.events.count
+      last_event = service.events.order(:created_at).last
+      assert_equal false, last_event.metadata["verified"]
+    end
+
+    test ".scan handles nil status when no previous events exist" do
+      service = ParticipantService.create!(name: "scan_nil_test")
+
+      verifier = ->(response) { true }
+      verifier.define_singleton_method(:to_s) { "test verifier" }
+
+      # No previous events, so newest.pick(:status) returns nil
+      # Should create first event
+      CloseEncounters.scan("scan_nil_test", status: 200, response: "First", verifier: verifier)
+
+      assert_equal 1, service.events.count
+      assert_equal 200, service.events.first.status
+    end
+
+    test ".scan metadata includes verification details" do
+      service = ParticipantService.create!(name: "scan_metadata_test")
+
+      verifier = ->(response) { response.include?("OK") }
+      verifier.define_singleton_method(:to_s) { "checks for OK" }
+
+      CloseEncounters.scan("scan_metadata_test", status: 200, response: "OK response", verifier: verifier)
+
+      event = service.events.first
+      assert_equal true, event.metadata["verified"]
+      assert_equal "checks for OK", event.metadata["verification"]
+    end
+
+    test ".contact handles nil status when no previous events exist" do
+      service = ParticipantService.create!(name: "contact_nil_test")
+
+      # No previous events, so newest.pick(:status) returns nil
+      # Should create first event
+      CloseEncounters.contact("contact_nil_test", status: 200, response: "First")
+
+      assert_equal 1, service.events.count
+      assert_equal 200, service.events.first.status
+    end
+  end
+end

--- a/test/close_encounters_string_status_fix_test.rb
+++ b/test/close_encounters_string_status_fix_test.rb
@@ -1,0 +1,96 @@
+require "test_helper"
+
+module CloseEncounters
+  class CloseEncountersStringStatusFixTest < ActiveSupport::TestCase
+    test "contact handles string status correctly" do
+      service = ParticipantService.create!(name: "string_contact_test")
+
+      # First call with integer status
+      CloseEncounters.contact("string_contact_test", status: 200, response: "First")
+      assert_equal 1, service.events.count
+
+      # Second call with STRING status - should not create duplicate
+      CloseEncounters.contact("string_contact_test", status: "200", response: "Second")
+      assert_equal 1, service.events.count, "String '200' should be treated same as integer 200"
+
+      # Different status as string should create new event
+      CloseEncounters.contact("string_contact_test", status: "404", response: "Error")
+      assert_equal 2, service.events.count
+      assert_equal 404, service.events.last.status
+    end
+
+    test "scan handles string status correctly" do
+      service = ParticipantService.create!(name: "string_scan_test")
+
+      passing_verifier = ->(response) { true }
+      passing_verifier.define_singleton_method(:to_s) { "always passes" }
+
+      # First call with integer status
+      CloseEncounters.scan("string_scan_test", status: 200, response: "First", verifier: passing_verifier)
+      assert_equal 1, service.events.count
+
+      # Second call with STRING status - should not create duplicate (verification passes)
+      CloseEncounters.scan("string_scan_test", status: "200", response: "Second", verifier: passing_verifier)
+      assert_equal 1, service.events.count, "String '200' should be treated same as integer 200"
+    end
+
+    test "scan with string status and failing verification" do
+      service = ParticipantService.create!(name: "string_scan_fail_test")
+
+      failing_verifier = ->(response) { false }
+      failing_verifier.define_singleton_method(:to_s) { "always fails" }
+
+      # First call creates event
+      CloseEncounters.scan("string_scan_fail_test", status: "200", response: "First", verifier: failing_verifier)
+      assert_equal 1, service.events.count
+
+      # Second call with string status and failing verification should create new event
+      # because 200 is in verify_scan_statuses and verification fails
+      CloseEncounters.scan("string_scan_fail_test", status: "200", response: "Second", verifier: failing_verifier)
+      assert_equal 2, service.events.count, "Should create new event when verification fails"
+    end
+
+    test "verify_scan_statuses works with string status" do
+      service = ParticipantService.create!(name: "verify_statuses_test")
+
+      # Create initial event
+      service.events.create!(status: 200, response: "Initial")
+
+      failing_verifier = ->(response) { false }
+      failing_verifier.define_singleton_method(:to_s) { "always fails" }
+
+      # String "200" should be converted to 200 and match verify_scan_statuses
+      CloseEncounters.scan("verify_statuses_test", status: "200", response: "Test", verifier: failing_verifier)
+
+      # Should create new event because status 200 is in verify_scan_statuses and verification fails
+      assert_equal 2, service.events.count
+    end
+
+    test "production scenario fixed" do
+      service = ParticipantService.create!(name: "production_fixed")
+
+      failing_verifier = ->(response) { false }
+      failing_verifier.define_singleton_method(:to_s) { "production verifier" }
+
+      # Simulate production where status might come as string
+      # First call
+      CloseEncounters.scan("production_fixed", status: "200", response: "Response 1", verifier: failing_verifier)
+      assert_equal 1, service.events.count
+
+      # Subsequent calls with string "200" and failing verification
+      # Should create new events because verification fails (intended behavior)
+      CloseEncounters.scan("production_fixed", status: "200", response: "Response 2", verifier: failing_verifier)
+      assert_equal 2, service.events.count
+
+      # But if we use contact instead (no verification)
+      service2 = ParticipantService.create!(name: "production_contact")
+
+      # Multiple calls with string status should NOT create duplicates
+      5.times do |i|
+        CloseEncounters.contact("production_contact", status: "200", response: "Response #{i}")
+      end
+
+      assert_equal 1, service2.events.count, "Contact should not create duplicates even with string status"
+    end
+  end
+end

--- a/test/close_encounters_test.rb
+++ b/test/close_encounters_test.rb
@@ -39,6 +39,8 @@ module CloseEncounters
       ENV.delete("CLOSE_ENCOUNTERS_AUTO_CONTACT")
       CloseEncounters.remove_instance_variable(:@configuration) if CloseEncounters.instance_variable_defined?(:@configuration)
       _(CloseEncounters.auto_contact?).must_equal false
+    ensure
+      ENV.delete("CLOSE_ENCOUNTERS_AUTO_CONTACT")
     end
 
     test ".auto_contact! enables automatic contact recording" do


### PR DESCRIPTION
Select events with a the table locked to prevent duplicates.